### PR TITLE
Fix thread safety crashes in BluetoothMeshService

### DIFF
--- a/bitchat/Services/MessageRetentionService.swift
+++ b/bitchat/Services/MessageRetentionService.swift
@@ -31,7 +31,10 @@ class MessageRetentionService {
     
     private init() {
         // Get documents directory
-        documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        guard let docsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            fatalError("Unable to access documents directory")
+        }
+        documentsDirectory = docsDir
         messagesDirectory = documentsDirectory.appendingPathComponent("Messages", isDirectory: true)
         
         // Create messages directory if it doesn't exist


### PR DESCRIPTION
## Summary
- Fixed threading issues causing crashes when users send messages
- Addressed all crash reports from TestFlight feedback

## Changes
- Added `NSLock` to synchronize access to `recentlySentMessages` Set, preventing concurrent modification crashes
- Fixed thread-unsafe access to `activePeers` Set by using the existing `activePeersLock`
- Removed force unwrapping in `MessageRetentionService` and `BluetoothMeshService` that could cause crashes
- Added defensive input validation to prevent processing empty messages

## Test plan
- [x] Build succeeds for iOS simulator
- [ ] Send messages rapidly with multiple users
- [ ] Background and foreground the app while sending messages  
- [ ] Test with no other users present
- [ ] Test on different iOS versions (18.5, 18.6, 26.0 beta)

## Crash Analysis
Analyzed 6 crash reports from TestFlight:
- 5 crashes were due to thread-unsafe Set operations in `sendMessage`
- 1 crash was an iOS system issue (SVG rendering) outside our control
- All threading issues have been addressed with proper synchronization