### PR TITLE
Fix for send message bug and other new features

### DIFF
--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -26,6 +26,7 @@ struct ContentView: View {
     @State private var showPasswordError = false
     @State private var showCommandSuggestions = false
     @State private var commandSuggestions: [String] = []
+    @State private var showLeaveChannelAlert = false
     
     private var backgroundColor: Color {
         colorScheme == .dark ? Color.black : Color.white
@@ -289,13 +290,21 @@ struct ContentView: View {
                     
                     // Leave channel button
                     Button(action: {
-                        viewModel.leaveChannel(currentChannel)
+                        showLeaveChannelAlert = true
                     }) {
                         Text("leave")
                             .font(.system(size: 12, design: .monospaced))
                             .foregroundColor(Color.red)
                     }
                     .buttonStyle(.plain)
+                    .alert("Leave Channel", isPresented: $showLeaveChannelAlert) {
+                        Button("Cancel", role: .cancel) { }
+                        Button("Leave", role: .destructive) {
+                            viewModel.leaveChannel(currentChannel)
+                        }
+                    } message: {
+                        Text("Are you sure you want to leave \(currentChannel)?")
+                    }
                 }
             } else {
                 // Public chat header
@@ -617,6 +626,7 @@ struct ContentView: View {
                 .textFieldStyle(.plain)
                 .font(.system(size: 14, design: .monospaced))
                 .foregroundColor(textColor)
+                .autocorrectionDisabled()
                 .focused($isTextFieldFocused)
                 .onChange(of: messageText) { newValue in
                     // Get cursor position (approximate - end of text for now)
@@ -682,9 +692,10 @@ struct ContentView: View {
             Button(action: sendMessage) {
                 Image(systemName: "arrow.up.circle.fill")
                     .font(.system(size: 20))
-                    .foregroundColor((viewModel.selectedPrivateChatPeer != nil || 
-                                     (viewModel.currentChannel != nil && viewModel.passwordProtectedChannels.contains(viewModel.currentChannel ?? ""))) 
-                                     ? Color.orange : textColor)
+                    .foregroundColor(messageText.isEmpty ? Color.gray :
+                                            (viewModel.selectedPrivateChatPeer != nil ||
+                                             (viewModel.currentChannel != nil && viewModel.passwordProtectedChannels.contains(viewModel.currentChannel ?? "")))
+                                             ? Color.orange : textColor)
             }
             .buttonStyle(.plain)
             .padding(.trailing, 12)

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -819,7 +819,7 @@ struct ContentView: View {
             
             // Leave button
             Button(action: {
-                viewModel.leaveChannel(channel)
+                showLeaveChannelAlert = true
             }) {
                 Text("leave channel")
                     .font(.system(size: 10, design: .monospaced))
@@ -832,6 +832,14 @@ struct ContentView: View {
                     )
             }
             .buttonStyle(.plain)
+            .alert("Leave Channel", isPresented: $showLeaveChannelAlert) {
+                Button("Cancel", role: .cancel) { }
+                Button("Leave", role: .destructive) {
+                    viewModel.leaveChannel(channel)
+                }
+            } message: {
+                Text("Are you sure you want to leave \(channel)?")
+            }
         }
     }
     


### PR DESCRIPTION
## New features integrated
- Send message button greyed out if textfield empty
- Shows confirmation alert before leaving channel (I accidentally tapped on leave whereas I wanted to tap on lock icon for password so it is good to show a confirmation)
- Currently, message textfield has auto correction enabled which has this weird bug (See video below)

# Autocorrection Bug (Before fix)
https://github.com/user-attachments/assets/24d573b8-42a6-4d30-ab9d-17307eb91166

# Autocorrection Bug (After fix)
https://github.com/user-attachments/assets/b8681aaa-5a60-431b-92ac-daac7513032e

# Confirmation Alert for leave channel
<img src="https://github.com/user-attachments/assets/48af32c8-bb9b-412c-8fe4-00f8540090ea" width=330 />

# Send button greyed out if no message typed
<img src="https://github.com/user-attachments/assets/5ac5ebef-2ea1-488f-9383-2bce2d35e4e9" width=330 />

