### PR TITLE
Add stats command and tests

### DIFF
--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 63;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -19,8 +19,6 @@
 		4274B6016F755946FBF2513E /* MessageRetentionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A85BFDDE65B4CD8BDF6DDB /* MessageRetentionService.swift */; };
 		4B747085D07A1BCE0F5BA612 /* BinaryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2136C3E22D02D4A8DBE7EAB /* BinaryProtocol.swift */; };
 		4E778E5A414571ACAC2A0F01 /* MessageRetentionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A85BFDDE65B4CD8BDF6DDB /* MessageRetentionService.swift */; };
-		5AF0505D2E1D8BD300B4F267 /* RelayStatisticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0505C2E1D8BD300B4F267 /* RelayStatisticsTests.swift */; };
-		5AF0505E2E1D8BD300B4F267 /* RelayStatisticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0505C2E1D8BD300B4F267 /* RelayStatisticsTests.swift */; };
 		5D95F2BFBE257A1225998389 /* BatteryOptimizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED176FF3B274E35C2D827894 /* BatteryOptimizer.swift */; };
 		61C81ED5F679D5E973EE0C07 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3448F84BF86A42A3CC4A9379 /* NotificationService.swift */; };
 		6DE056E1EE9850E9FBF50157 /* BitchatProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229F17B68CFF7AB1BC91C847 /* BitchatProtocol.swift */; };
@@ -131,7 +129,6 @@
 		3FA8FF26ABDC1C642A8C7AE5 /* BitchatMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitchatMessageTests.swift; sourceTree = "<group>"; };
 		527EB217EFDFAD4CF1C91F07 /* bitchat.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = bitchat.entitlements; sourceTree = "<group>"; };
 		53D535D9CE0B875F47402290 /* BinaryProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryProtocolTests.swift; sourceTree = "<group>"; };
-		5AF0505C2E1D8BD300B4F267 /* RelayStatisticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayStatisticsTests.swift; sourceTree = "<group>"; };
 		61F92EBA29C47C0FCC482F1F /* bitchatShareExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = bitchatShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		67A85BFDDE65B4CD8BDF6DDB /* MessageRetentionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRetentionService.swift; sourceTree = "<group>"; };
 		6DC1563390A15C042D059CF9 /* EncryptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionService.swift; sourceTree = "<group>"; };
@@ -249,7 +246,6 @@
 				D69A18D27F9A565FD6041E12 /* Info.plist */,
 				8DE9CDF66D4E52D268851048 /* MessagePaddingTests.swift */,
 				036A1A705AAF9EC21F4354BE /* PasswordProtectedChannelTests.swift */,
-				5AF0505C2E1D8BD300B4F267 /* RelayStatisticsTests.swift */,
 			);
 			path = bitchatTests;
 			sourceTree = "<group>";
@@ -397,6 +393,7 @@
 			);
 			mainGroup = 18198ED912AAF495D8AF7763;
 			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 54;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -489,7 +486,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5AF0505D2E1D8BD300B4F267 /* RelayStatisticsTests.swift in Sources */,
 				8F0BFC2D2B2A5E7B70C3B485 /* BinaryProtocolTests.swift in Sources */,
 				2E71E320EA921498C57E023B /* BitchatMessageTests.swift in Sources */,
 				C91FDE97070433E6CFE95C55 /* BloomFilterTests.swift in Sources */,
@@ -502,7 +498,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5AF0505E2E1D8BD300B4F267 /* RelayStatisticsTests.swift in Sources */,
 				CDAD6629EB69916B95C80DAF /* BinaryProtocolTests.swift in Sources */,
 				0DAFF1DDE9BA83FF648D5AB3 /* BitchatMessageTests.swift in Sources */,
 				846E2B446E36639159704730 /* BloomFilterTests.swift in Sources */,

--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 63;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -19,6 +19,8 @@
 		4274B6016F755946FBF2513E /* MessageRetentionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A85BFDDE65B4CD8BDF6DDB /* MessageRetentionService.swift */; };
 		4B747085D07A1BCE0F5BA612 /* BinaryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2136C3E22D02D4A8DBE7EAB /* BinaryProtocol.swift */; };
 		4E778E5A414571ACAC2A0F01 /* MessageRetentionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A85BFDDE65B4CD8BDF6DDB /* MessageRetentionService.swift */; };
+		5AF0505D2E1D8BD300B4F267 /* RelayStatisticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0505C2E1D8BD300B4F267 /* RelayStatisticsTests.swift */; };
+		5AF0505E2E1D8BD300B4F267 /* RelayStatisticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0505C2E1D8BD300B4F267 /* RelayStatisticsTests.swift */; };
 		5D95F2BFBE257A1225998389 /* BatteryOptimizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED176FF3B274E35C2D827894 /* BatteryOptimizer.swift */; };
 		61C81ED5F679D5E973EE0C07 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3448F84BF86A42A3CC4A9379 /* NotificationService.swift */; };
 		6DE056E1EE9850E9FBF50157 /* BitchatProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229F17B68CFF7AB1BC91C847 /* BitchatProtocol.swift */; };
@@ -129,6 +131,7 @@
 		3FA8FF26ABDC1C642A8C7AE5 /* BitchatMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitchatMessageTests.swift; sourceTree = "<group>"; };
 		527EB217EFDFAD4CF1C91F07 /* bitchat.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = bitchat.entitlements; sourceTree = "<group>"; };
 		53D535D9CE0B875F47402290 /* BinaryProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryProtocolTests.swift; sourceTree = "<group>"; };
+		5AF0505C2E1D8BD300B4F267 /* RelayStatisticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayStatisticsTests.swift; sourceTree = "<group>"; };
 		61F92EBA29C47C0FCC482F1F /* bitchatShareExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = bitchatShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		67A85BFDDE65B4CD8BDF6DDB /* MessageRetentionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRetentionService.swift; sourceTree = "<group>"; };
 		6DC1563390A15C042D059CF9 /* EncryptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionService.swift; sourceTree = "<group>"; };
@@ -246,6 +249,7 @@
 				D69A18D27F9A565FD6041E12 /* Info.plist */,
 				8DE9CDF66D4E52D268851048 /* MessagePaddingTests.swift */,
 				036A1A705AAF9EC21F4354BE /* PasswordProtectedChannelTests.swift */,
+				5AF0505C2E1D8BD300B4F267 /* RelayStatisticsTests.swift */,
 			);
 			path = bitchatTests;
 			sourceTree = "<group>";
@@ -393,7 +397,6 @@
 			);
 			mainGroup = 18198ED912AAF495D8AF7763;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 54;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -486,6 +489,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5AF0505D2E1D8BD300B4F267 /* RelayStatisticsTests.swift in Sources */,
 				8F0BFC2D2B2A5E7B70C3B485 /* BinaryProtocolTests.swift in Sources */,
 				2E71E320EA921498C57E023B /* BitchatMessageTests.swift in Sources */,
 				C91FDE97070433E6CFE95C55 /* BloomFilterTests.swift in Sources */,
@@ -498,6 +502,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5AF0505E2E1D8BD300B4F267 /* RelayStatisticsTests.swift in Sources */,
 				CDAD6629EB69916B95C80DAF /* BinaryProtocolTests.swift in Sources */,
 				0DAFF1DDE9BA83FF648D5AB3 /* BitchatMessageTests.swift in Sources */,
 				846E2B446E36639159704730 /* BloomFilterTests.swift in Sources */,

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -2456,6 +2456,42 @@ extension ChatViewModel: BitchatDelegate {
                 messages.append(systemMessage)
             }
             
+        case "/stats":
+            // Show relay statistics
+            let stats = meshService.getRelayStatistics()
+            let sessionDurationMinutes = Int(stats.sessionDuration / 60)
+            let sessionDurationHours = sessionDurationMinutes / 60
+            let remainingMinutes = sessionDurationMinutes % 60
+            
+            var durationString: String
+            if sessionDurationHours > 0 {
+                durationString = "\(sessionDurationHours)h \(remainingMinutes)m"
+            } else {
+                durationString = "\(remainingMinutes)m"
+            }
+            
+            let statsContent = """
+Relay statistics:
+
+session (\(durationString)):
+• messages relayed: \(stats.sessionMessages)
+• unique peers helped: \(stats.sessionPeers)
+
+all time:
+• total messages relayed: \(stats.totalMessages)
+• total peers helped: \(stats.totalPeers)
+
+You're helping keep the mesh network alive by relaying messages for others!
+"""
+            
+            let systemMessage = BitchatMessage(
+                sender: "system",
+                content: statsContent,
+                timestamp: Date(),
+                isRelay: false
+            )
+            messages.append(systemMessage)
+            
         default:
             // Unknown command
             let systemMessage = BitchatMessage(

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -111,6 +111,7 @@ struct AppInfoView: View {
                             Text("/m @name - send private message")
                             Text("/w - see who's online")
                             Text("/channels - show all discovered channels")
+                            Text("/stats - show relay statistics")
                             Text("/block @name - block a peer")
                             Text("/block - list blocked peers")
                             Text("/unblock @name - unblock a peer")

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -556,6 +556,7 @@ struct ContentView: View {
                         (["/channels"], nil, "show all discovered channels"),
                         (["/slap"], "<nickname>", "slap someone with a trout"),
                         (["/unblock"], "<nickname>", "unblock a peer"),
+                        (["/stats"], nil, "show relay statistics"),
                         (["/w"], nil, "see who's online")
                     ]
                     
@@ -664,6 +665,7 @@ struct ContentView: View {
                             ("/j", "join or create a channel"),
                             ("/m", "send private message"),
                             ("/slap", "slap someone with a trout"),
+                            ("/stats", "show relay statistics"),
                             ("/unblock", "unblock a peer"),
                             ("/w", "see who's online")
                         ]

--- a/bitchatTests/RelayStatisticsTests.swift
+++ b/bitchatTests/RelayStatisticsTests.swift
@@ -1,0 +1,109 @@
+//
+// RelayStatisticsTests.swift
+// bitchatTests
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import XCTest
+@testable import bitchat
+
+class RelayStatisticsTests: XCTestCase {
+    
+    var meshService: BluetoothMeshService!
+    
+    override func setUp() {
+        super.setUp()
+        meshService = BluetoothMeshService()
+        
+        // Clear any existing statistics
+        meshService.resetRelayStatistics()
+        
+        // Clear UserDefaults for clean test state
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "bitchat.relayStats")
+    }
+    
+    override func tearDown() {
+        // Clean up UserDefaults after tests
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "bitchat.relayStats")
+        
+        meshService = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Basic Statistics Tests
+    
+    func testInitialStatistics() {
+        let stats = meshService.getRelayStatistics()
+        
+        XCTAssertEqual(stats.totalMessages, 0)
+        XCTAssertEqual(stats.totalPeers, 0)
+        XCTAssertEqual(stats.sessionMessages, 0)
+        XCTAssertEqual(stats.sessionPeers, 0)
+        XCTAssertGreaterThan(stats.sessionDuration, 0)
+    }
+    
+    func testSessionReset() {
+        // Simulate some relay activity first
+        let initialStats = meshService.getRelayStatistics()
+        
+        // Reset statistics
+        meshService.resetRelayStatistics()
+        
+        let resetStats = meshService.getRelayStatistics()
+        XCTAssertEqual(resetStats.totalMessages, 0)
+        XCTAssertEqual(resetStats.totalPeers, 0)
+        XCTAssertEqual(resetStats.sessionMessages, 0)
+        XCTAssertEqual(resetStats.sessionPeers, 0)
+        XCTAssertLessThan(resetStats.sessionDuration, initialStats.sessionDuration)
+    }
+    
+    // MARK: - Statistics Persistence Tests
+    
+    func testStatisticsPersistence() {
+        // Create a new service instance to test loading
+        let service1 = BluetoothMeshService()
+        
+        // Get initial stats (should be 0)
+        let initialStats = service1.getRelayStatistics()
+        XCTAssertEqual(initialStats.totalMessages, 0)
+        XCTAssertEqual(initialStats.totalPeers, 0)
+        
+        // Simulate saving some statistics by manually setting UserDefaults
+        // (since we can't easily trigger actual relay events in unit tests)
+        let defaults = UserDefaults.standard
+        defaults.set(5, forKey: "bitchat.relayStats.totalMessages")
+        defaults.set(3, forKey: "bitchat.relayStats.totalPeers")
+        
+        // Create a new service instance to test loading
+        let service2 = BluetoothMeshService()
+        let loadedStats = service2.getRelayStatistics()
+        
+        XCTAssertEqual(loadedStats.totalMessages, 5)
+        XCTAssertEqual(loadedStats.totalPeers, 3)
+    }
+    
+    // MARK: - Integration Test
+    
+    func testRelayStatisticsIntegration() {
+        // Test that the /stats command works
+        let chatViewModel = ChatViewModel()
+        
+        // Simulate sending /stats command
+        let initialMessageCount = chatViewModel.messages.count
+        chatViewModel.sendMessage("/stats")
+        
+        // Check that a system message was added
+        XCTAssertEqual(chatViewModel.messages.count, initialMessageCount + 1)
+        
+        let lastMessage = chatViewModel.messages.last
+        XCTAssertNotNil(lastMessage)
+        XCTAssertEqual(lastMessage?.sender, "system")
+        XCTAssertTrue(lastMessage?.content.contains("Relay statistics:") ?? false)
+        XCTAssertTrue(lastMessage?.content.contains("total messages relayed:") ?? false)
+        XCTAssertTrue(lastMessage?.content.contains("messages relayed:") ?? false)
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature for tracking and displaying relay statistics in the `bitchat` app, along with associated tests and updates to the user interface. Key changes include the addition of relay statistics functionality in the `BluetoothMeshService`, a new `/stats` command for users to view the statistics, and unit tests to ensure the feature works as expected.

### Relay Statistics Feature

* **Relay Statistics Tracking**: Added properties and methods in `BluetoothMeshService` to track and persist relay statistics, such as the number of messages relayed and unique peers helped, both for the current session and all time. (`bitchat/Services/BluetoothMeshService.swift`) [[1]](diffhunk://#diff-c3b19558707eeca41e857108beebab8274d5fef9c105025d81945562b7371a58R177-R247) [[2]](diffhunk://#diff-c3b19558707eeca41e857108beebab8274d5fef9c105025d81945562b7371a58R340-R342) [[3]](diffhunk://#diff-c3b19558707eeca41e857108beebab8274d5fef9c105025d81945562b7371a58R1625-R1627)

* **New `/stats` Command**: Implemented the `/stats` command in `ChatViewModel` to display relay statistics to users in a formatted system message. (`bitchat/ViewModels/ChatViewModel.swift`)