### PR TITLE
Fixing macOS build

### DIFF
--- a/bitchat/Views/LinkPreviewView.swift
+++ b/bitchat/Views/LinkPreviewView.swift
@@ -15,8 +15,9 @@ struct LinkPreviewView: View {
     let url: URL
     let title: String?
     @Environment(\.colorScheme) var colorScheme
+    #if os(iOS)
     @State private var metadata: LPLinkMetadata?
-    
+    #endif
     private var textColor: Color {
         colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0)
     }
@@ -85,11 +86,13 @@ struct LinkPreviewView: View {
                 
                 VStack(alignment: .leading, spacing: 4) {
                     // Title
+                    #if os(iOS)
                     Text(metadata?.title ?? title ?? url.host ?? "Link")
                         .font(.system(size: 14, weight: .semibold, design: .monospaced))
                         .foregroundColor(textColor)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
+                    #endif
                     
                     // Host
                     Text(url.host ?? url.absoluteString)


### PR DESCRIPTION
Includes guard around `LPLinkMetadata` which only should work for iOS

Error Message when building for macOS:
```
~/bitchat/bitchat/Views/LinkPreviewView.swift:19:34 Cannot find type 'LPLinkMetadata' in scope
```


Change:
```
#if os(iOS)
  @State private var metadata: LPLinkMetadata?
#endif
```