### PR TITLE
Add bluetooth entitlement for macOS

### DIFF
--- a/bitchat/bitchat.entitlements
+++ b/bitchat/bitchat.entitlements
@@ -8,5 +8,7 @@
 	<array>
 		<string>group.chat.bitchat</string>
 	</array>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Adds `com.apple.security.device.bluetooth` entitlement to enable Bluetooth connectivity for MacOS.

**Changes**:
```xml
<key>com.apple.security.device.bluetooth</key>
<true/>
```