### PR TITLE
Add dark mode

### DIFF
--- a/bitchat.xcodeproj/project.pbxproj
+++ b/bitchat.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		F00B713D5053617FB5F3F1BE /* MessagePaddingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE9CDF66D4E52D268851048 /* MessagePaddingTests.swift */; };
 		F455F011B3B648ADA233F998 /* BinaryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2136C3E22D02D4A8DBE7EAB /* BinaryProtocol.swift */; };
 		FB8819B4C84FAFEF5C36B216 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136696FC4436A02D98CE6A77 /* KeychainManager.swift */; };
+		A1B2C3D4E5F6789012345678 /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6789012345679 /* ThemeManager.swift */; };
+		A1B2C3D4E5F6789012345680 /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6789012345679 /* ThemeManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -149,6 +151,7 @@
 		EA706D8E5097785414646A8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		ED176FF3B274E35C2D827894 /* BatteryOptimizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryOptimizer.swift; sourceTree = "<group>"; };
 		EF625BB3AD919322C01A46B2 /* BitchatApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitchatApp.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6789012345679 /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -260,6 +263,7 @@
 				67A85BFDDE65B4CD8BDF6DDB /* MessageRetentionService.swift */,
 				AA4D7595A613F7ED3B386132 /* MessageRetryService.swift */,
 				3448F84BF86A42A3CC4A9379 /* NotificationService.swift */,
+				A1B2C3D4E5F6789012345679 /* ThemeManager.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -281,8 +285,6 @@
 				D8120CFFA88B852C3D106FA6 /* PBXTargetDependency */,
 			);
 			name = bitchat_macOS;
-			packageProductDependencies = (
-			);
 			productName = bitchat_macOS;
 			productReference = 7EEBDA723E1CFD88758DA4AC /* bitchat.app */;
 			productType = "com.apple.product-type.application";
@@ -299,8 +301,6 @@
 				4AA8605DCAA64A45657EF0CA /* PBXTargetDependency */,
 			);
 			name = bitchatTests_macOS;
-			packageProductDependencies = (
-			);
 			productName = bitchatTests_macOS;
 			productReference = 03C57F452B55FD0FD8F51421 /* bitchatTests_macOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -316,8 +316,6 @@
 			dependencies = (
 			);
 			name = bitchatShareExtension;
-			packageProductDependencies = (
-			);
 			productName = bitchatShareExtension;
 			productReference = 61F92EBA29C47C0FCC482F1F /* bitchatShareExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -334,8 +332,6 @@
 				D8C09F21DB7DC06E8E672C21 /* PBXTargetDependency */,
 			);
 			name = bitchatTests_iOS;
-			packageProductDependencies = (
-			);
 			productName = bitchatTests_iOS;
 			productReference = C0DB1DE27F0AAB5092663E8E /* bitchatTests_iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -354,8 +350,6 @@
 				6EB655BA5DB11909C1DEC460 /* PBXTargetDependency */,
 			);
 			name = bitchat_iOS;
-			packageProductDependencies = (
-			);
 			productName = bitchat_iOS;
 			productReference = 997D512074C64904D75DDD40 /* bitchat.app */;
 			productType = "com.apple.product-type.application";
@@ -392,8 +386,6 @@
 				en,
 			);
 			mainGroup = 18198ED912AAF495D8AF7763;
-			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 54;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -455,6 +447,7 @@
 				C99763A4761567F587D21688 /* MessageRetryService.swift in Sources */,
 				749D8CF8A362B6CD0786782D /* NotificationService.swift in Sources */,
 				0245710AEAA58AD0A1425234 /* OptimizedBloomFilter.swift in Sources */,
+				A1B2C3D4E5F6789012345680 /* ThemeManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -479,6 +472,7 @@
 				CEAE115C9C3EB3C4ED82F128 /* MessageRetryService.swift in Sources */,
 				61C81ED5F679D5E973EE0C07 /* NotificationService.swift in Sources */,
 				1F48A8CEEE9399D1EBD08F0C /* OptimizedBloomFilter.swift in Sources */,
+				A1B2C3D4E5F6789012345678 /* ThemeManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/bitchat/BitchatApp.swift
+++ b/bitchat/BitchatApp.swift
@@ -12,6 +12,7 @@ import UserNotifications
 @main
 struct BitchatApp: App {
     @StateObject private var chatViewModel = ChatViewModel()
+    @StateObject private var themeManager = ThemeManager.shared
     #if os(iOS)
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     #endif
@@ -24,6 +25,7 @@ struct BitchatApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(chatViewModel)
+                .environmentObject(themeManager)
                 .onAppear {
                     NotificationDelegate.shared.chatViewModel = chatViewModel
                     #if os(iOS)

--- a/bitchat/Services/ThemeManager.swift
+++ b/bitchat/Services/ThemeManager.swift
@@ -1,0 +1,166 @@
+//
+// ThemeManager.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import SwiftUI
+
+class ThemeManager: ObservableObject {
+    static let shared = ThemeManager()
+    
+    @Published var isDarkMode: Bool {
+        didSet {
+            UserDefaults.standard.set(isDarkMode, forKey: "bitchat.isDarkMode")
+        }
+    }
+    
+    private init() {
+        self.isDarkMode = UserDefaults.standard.bool(forKey: "bitchat.isDarkMode")
+    }
+    
+    // MARK: - Cursor IDE-inspired colors with neon accents
+    
+    // Main background colors - not too black, like Cursor IDE
+    var backgroundColor: Color {
+        isDarkMode ? Color(hex: "1E1E1E") : Color.white
+    }
+    
+    var secondaryBackgroundColor: Color {
+        isDarkMode ? Color(hex: "252526") : Color(hex: "F5F5F5")
+    }
+    
+    var tertiaryBackgroundColor: Color {
+        isDarkMode ? Color(hex: "2D2D30") : Color(hex: "EBEBEB")
+    }
+    
+    // Text colors
+    var primaryTextColor: Color {
+        isDarkMode ? Color(hex: "CCCCCC") : Color(hex: "1E1E1E")
+    }
+    
+    var secondaryTextColor: Color {
+        isDarkMode ? Color(hex: "999999") : Color(hex: "6E6E6E")
+    }
+    
+    // Neon accent colors
+    var neonGreen: Color {
+        Color(hex: "00FF88")
+    }
+    
+    var neonBlue: Color {
+        Color(hex: "00D9FF")
+    }
+    
+    var neonPurple: Color {
+        Color(hex: "BD93F9")
+    }
+    
+    var neonPink: Color {
+        Color(hex: "FF79C6")
+    }
+    
+    var neonYellow: Color {
+        Color(hex: "F1FA8C")
+    }
+    
+    var neonOrange: Color {
+        Color(hex: "FFB86C")
+    }
+    
+    // UI Element colors
+    var dividerColor: Color {
+        isDarkMode ? Color(hex: "3E3E42") : Color(hex: "E5E5E7")
+    }
+    
+    var toggleTintColor: Color {
+        isDarkMode ? neonBlue : Color.blue
+    }
+    
+    // Message colors
+    var systemMessageColor: Color {
+        isDarkMode ? Color(hex: "858585") : Color(hex: "8E8E93")
+    }
+    
+    var senderColor: Color {
+        isDarkMode ? neonGreen : Color(red: 0, green: 0.7, blue: 0)
+    }
+    
+    var timestampColor: Color {
+        isDarkMode ? Color(hex: "6E6E73") : Color(hex: "8E8E93")
+    }
+    
+    var mentionBackgroundColor: Color {
+        isDarkMode ? neonPurple.opacity(0.2) : Color.purple.opacity(0.1)
+    }
+    
+    var mentionTextColor: Color {
+        isDarkMode ? neonPurple : Color.purple
+    }
+    
+    var linkColor: Color {
+        isDarkMode ? neonBlue : Color.blue
+    }
+    
+    var privateMessageColor: Color {
+        isDarkMode ? neonOrange : Color.orange
+    }
+    
+    var channelColor: Color {
+        isDarkMode ? neonBlue : Color.blue
+    }
+    
+    var favoriteColor: Color {
+        isDarkMode ? neonYellow : Color.yellow
+    }
+    
+    var errorColor: Color {
+        Color.red
+    }
+    
+    // Button and interactive element colors
+    var buttonBackgroundColor: Color {
+        isDarkMode ? Color(hex: "3E3E42") : Color(hex: "E5E5E7")
+    }
+    
+    var buttonHoverColor: Color {
+        isDarkMode ? Color(hex: "4E4E52") : Color(hex: "D5D5D7")
+    }
+    
+    // Toggle theme
+    func toggleTheme() {
+        withAnimation(.easeInOut(duration: 0.3)) {
+            isDarkMode.toggle()
+        }
+    }
+}
+
+// MARK: - Color Extension for Hex Support
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (255, 0, 0, 0)
+        }
+        
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+} 

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -2,19 +2,7 @@ import SwiftUI
 
 struct AppInfoView: View {
     @Environment(\.dismiss) var dismiss
-    @Environment(\.colorScheme) var colorScheme
-    
-    private var backgroundColor: Color {
-        colorScheme == .dark ? Color.black : Color.white
-    }
-    
-    private var textColor: Color {
-        colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0)
-    }
-    
-    private var secondaryTextColor: Color {
-        colorScheme == .dark ? Color.green.opacity(0.8) : Color(red: 0, green: 0.5, blue: 0).opacity(0.8)
-    }
+    @EnvironmentObject var themeManager: ThemeManager
     
     var body: some View {
         #if os(macOS)
@@ -26,10 +14,10 @@ struct AppInfoView: View {
                     dismiss()
                 }
                 .buttonStyle(.plain)
-                .foregroundColor(textColor)
+                .foregroundColor(themeManager.primaryTextColor)
                 .padding()
             }
-            .background(backgroundColor.opacity(0.95))
+            .background(themeManager.backgroundColor.opacity(0.95))
             
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
@@ -37,11 +25,11 @@ struct AppInfoView: View {
                     VStack(alignment: .center, spacing: 8) {
                         Text("bitchat*")
                             .font(.system(size: 32, weight: .bold, design: .monospaced))
-                            .foregroundColor(textColor)
+                            .foregroundColor(themeManager.primaryTextColor)
                         
                         Text("secure mesh chat")
                             .font(.system(size: 16, design: .monospaced))
-                            .foregroundColor(secondaryTextColor)
+                            .foregroundColor(themeManager.secondaryTextColor)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical)
@@ -99,7 +87,7 @@ struct AppInfoView: View {
                             Text("• Triple-tap the logo for panic mode")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundColor(themeManager.primaryTextColor)
                     }
                     
                     // Commands
@@ -119,7 +107,7 @@ struct AppInfoView: View {
                             Text("/slap @name - slap with a trout")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundColor(themeManager.primaryTextColor)
                     }
                     
                     // Technical Details
@@ -137,7 +125,7 @@ struct AppInfoView: View {
                             Text("Storage: Keychain for passwords, encrypted retention")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundColor(themeManager.primaryTextColor)
                     }
                     
                     // Version
@@ -145,14 +133,14 @@ struct AppInfoView: View {
                         Spacer()
                         Text("Version 1.0.0")
                             .font(.system(size: 12, design: .monospaced))
-                            .foregroundColor(secondaryTextColor)
+                            .foregroundColor(themeManager.secondaryTextColor)
                         Spacer()
                     }
                     .padding(.top)
                 }
                 .padding()
             }
-            .background(backgroundColor)
+            .background(themeManager.backgroundColor)
         }
         .frame(width: 600, height: 700)
         #else
@@ -163,11 +151,11 @@ struct AppInfoView: View {
                     VStack(alignment: .center, spacing: 8) {
                         Text("bitchat*")
                             .font(.system(size: 32, weight: .bold, design: .monospaced))
-                            .foregroundColor(textColor)
+                            .foregroundColor(themeManager.primaryTextColor)
                         
                         Text("secure mesh chat")
                             .font(.system(size: 16, design: .monospaced))
-                            .foregroundColor(secondaryTextColor)
+                            .foregroundColor(themeManager.secondaryTextColor)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical)
@@ -225,7 +213,7 @@ struct AppInfoView: View {
                             Text("• Triple-tap the logo for panic mode")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundColor(themeManager.primaryTextColor)
                     }
                     
                     // Commands
@@ -245,7 +233,7 @@ struct AppInfoView: View {
                             Text("/slap @name - slap with a trout")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundColor(themeManager.primaryTextColor)
                     }
                     
                     // Technical Details
@@ -263,7 +251,7 @@ struct AppInfoView: View {
                             Text("Storage: Keychain for passwords, encrypted retention")
                         }
                         .font(.system(size: 14, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundColor(themeManager.primaryTextColor)
                     }
                     
                     // Version
@@ -271,21 +259,21 @@ struct AppInfoView: View {
                         Spacer()
                         Text("Version 1.0.0")
                             .font(.system(size: 12, design: .monospaced))
-                            .foregroundColor(secondaryTextColor)
+                            .foregroundColor(themeManager.secondaryTextColor)
                         Spacer()
                     }
                     .padding(.top)
                 }
                 .padding()
             }
-            .background(backgroundColor)
+            .background(themeManager.backgroundColor)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Done") {
                         dismiss()
                     }
-                    .foregroundColor(textColor)
+                    .foregroundColor(themeManager.primaryTextColor)
                 }
             }
         }
@@ -295,11 +283,7 @@ struct AppInfoView: View {
 
 struct SectionHeader: View {
     let title: String
-    @Environment(\.colorScheme) var colorScheme
-    
-    private var textColor: Color {
-        colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0)
-    }
+    @EnvironmentObject var themeManager: ThemeManager
     
     init(_ title: String) {
         self.title = title
@@ -308,7 +292,7 @@ struct SectionHeader: View {
     var body: some View {
         Text(title.uppercased())
             .font(.system(size: 16, weight: .bold, design: .monospaced))
-            .foregroundColor(textColor)
+            .foregroundColor(themeManager.primaryTextColor)
             .padding(.top, 8)
     }
 }
@@ -317,31 +301,23 @@ struct FeatureRow: View {
     let icon: String
     let title: String
     let description: String
-    @Environment(\.colorScheme) var colorScheme
-    
-    private var textColor: Color {
-        colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0)
-    }
-    
-    private var secondaryTextColor: Color {
-        colorScheme == .dark ? Color.green.opacity(0.8) : Color(red: 0, green: 0.5, blue: 0).opacity(0.8)
-    }
+    @EnvironmentObject var themeManager: ThemeManager
     
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 20))
-                .foregroundColor(textColor)
+                .foregroundColor(themeManager.primaryTextColor)
                 .frame(width: 30)
             
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.system(size: 14, weight: .semibold, design: .monospaced))
-                    .foregroundColor(textColor)
+                    .foregroundColor(themeManager.primaryTextColor)
                 
                 Text(description)
                     .font(.system(size: 12, design: .monospaced))
-                    .foregroundColor(secondaryTextColor)
+                    .foregroundColor(themeManager.secondaryTextColor)
                     .fixedSize(horizontal: false, vertical: true)
             }
             

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -10,10 +10,10 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var viewModel: ChatViewModel
+    @EnvironmentObject var themeManager: ThemeManager
     @State private var messageText = ""
     @State private var textFieldSelection: NSRange? = nil
     @FocusState private var isTextFieldFocused: Bool
-    @Environment(\.colorScheme) var colorScheme
     @State private var showPeerList = false
     @State private var showSidebar = false
     @State private var sidebarDragOffset: CGFloat = 0
@@ -28,18 +28,6 @@ struct ContentView: View {
     @State private var commandSuggestions: [String] = []
     @State private var showLeaveChannelAlert = false
     
-    private var backgroundColor: Color {
-        colorScheme == .dark ? Color.black : Color.white
-    }
-    
-    private var textColor: Color {
-        colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0)
-    }
-    
-    private var secondaryTextColor: Color {
-        colorScheme == .dark ? Color.green.opacity(0.8) : Color(red: 0, green: 0.5, blue: 0).opacity(0.8)
-    }
-    
     var body: some View {
         ZStack {
             // Main content
@@ -52,8 +40,8 @@ struct ContentView: View {
                         Divider()
                         inputView
                     }
-                    .background(backgroundColor)
-                    .foregroundColor(textColor)
+                    .background(themeManager.backgroundColor)
+                    .foregroundColor(themeManager.primaryTextColor)
                     .gesture(
                         DragGesture()
                             .onChanged { value in
@@ -181,7 +169,7 @@ struct ContentView: View {
                         Text("back")
                             .font(.system(size: 14, design: .monospaced))
                     }
-                    .foregroundColor(textColor)
+                    .foregroundColor(themeManager.primaryTextColor)
                 }
                 .buttonStyle(.plain)
                 
@@ -190,10 +178,10 @@ struct ContentView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 14))
-                        .foregroundColor(Color.orange)
+                        .foregroundColor(themeManager.privateMessageColor)
                     Text("\(privatePeerNick)")
                         .font(.system(size: 16, weight: .medium, design: .monospaced))
-                        .foregroundColor(Color.orange)
+                        .foregroundColor(themeManager.privateMessageColor)
                 }
                 .frame(maxWidth: .infinity)
                 
@@ -205,7 +193,7 @@ struct ContentView: View {
                 }) {
                     Image(systemName: viewModel.isFavorite(peerID: privatePeerID) ? "star.fill" : "star")
                         .font(.system(size: 16))
-                        .foregroundColor(viewModel.isFavorite(peerID: privatePeerID) ? Color.yellow : textColor)
+                        .foregroundColor(viewModel.isFavorite(peerID: privatePeerID) ? themeManager.favoriteColor : themeManager.primaryTextColor)
                 }
                 .buttonStyle(.plain)
             } else if let currentChannel = viewModel.currentChannel {
@@ -219,7 +207,7 @@ struct ContentView: View {
                         Text("back")
                             .font(.system(size: 14, design: .monospaced))
                     }
-                    .foregroundColor(textColor)
+                    .foregroundColor(themeManager.primaryTextColor)
                 }
                 .buttonStyle(.plain)
                 
@@ -235,11 +223,11 @@ struct ContentView: View {
                         if viewModel.passwordProtectedChannels.contains(currentChannel) {
                             Image(systemName: "lock.fill")
                                 .font(.system(size: 14))
-                                .foregroundColor(Color.orange)
+                                .foregroundColor(themeManager.privateMessageColor)
                         }
                         Text("channel: \(currentChannel)")
                             .font(.system(size: 16, weight: .medium, design: .monospaced))
-                            .foregroundColor(viewModel.passwordProtectedChannels.contains(currentChannel) ? Color.orange : Color.blue)
+                            .foregroundColor(viewModel.passwordProtectedChannels.contains(currentChannel) ? themeManager.privateMessageColor : themeManager.channelColor)
                     }
                 }
                 .buttonStyle(.plain)
@@ -252,7 +240,7 @@ struct ContentView: View {
                     if viewModel.retentionEnabledChannels.contains(currentChannel) {
                         Image(systemName: "bookmark.fill")
                             .font(.system(size: 16))
-                            .foregroundColor(Color.yellow)
+                            .foregroundColor(themeManager.favoriteColor)
                             .help("Messages in this channel are being saved locally")
                     }
                     
@@ -263,7 +251,7 @@ struct ContentView: View {
                         }) {
                             Image(systemName: viewModel.retentionEnabledChannels.contains(currentChannel) ? "bookmark.slash" : "bookmark")
                                 .font(.system(size: 16))
-                                .foregroundColor(textColor)
+                                .foregroundColor(themeManager.primaryTextColor)
                         }
                         .buttonStyle(.plain)
                         .help(viewModel.retentionEnabledChannels.contains(currentChannel) ? "Disable message retention" : "Enable message retention")
@@ -283,7 +271,7 @@ struct ContentView: View {
                         }) {
                             Image(systemName: viewModel.passwordProtectedChannels.contains(currentChannel) ? "lock.fill" : "lock")
                                 .font(.system(size: 16))
-                                .foregroundColor(viewModel.passwordProtectedChannels.contains(currentChannel) ? Color.yellow : textColor)
+                                .foregroundColor(viewModel.passwordProtectedChannels.contains(currentChannel) ? themeManager.favoriteColor : themeManager.primaryTextColor)
                         }
                         .buttonStyle(.plain)
                     }
@@ -311,7 +299,7 @@ struct ContentView: View {
                 HStack(spacing: 4) {
                     Text("bitchat*")
                         .font(.system(size: 18, weight: .medium, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundColor(themeManager.primaryTextColor)
                         .onTapGesture(count: 3) {
                             // PANIC: Triple-tap to clear all data
                             viewModel.panicClearAllData()
@@ -324,13 +312,13 @@ struct ContentView: View {
                     HStack(spacing: 0) {
                         Text("@")
                             .font(.system(size: 14, design: .monospaced))
-                            .foregroundColor(secondaryTextColor)
+                            .foregroundColor(themeManager.secondaryTextColor)
                         
                         TextField("nickname", text: $viewModel.nickname)
                             .textFieldStyle(.plain)
                             .font(.system(size: 14, design: .monospaced))
                             .frame(maxWidth: 100)
-                            .foregroundColor(textColor)
+                            .foregroundColor(themeManager.primaryTextColor)
                             .onChange(of: viewModel.nickname) { _ in
                                 viewModel.saveNickname()
                             }
@@ -356,7 +344,7 @@ struct ContentView: View {
                     if !viewModel.unreadPrivateMessages.isEmpty {
                         Image(systemName: "envelope.fill")
                             .font(.system(size: 12))
-                            .foregroundColor(Color.orange)
+                            .foregroundColor(themeManager.privateMessageColor)
                     }
                     
                     let otherPeersCount = viewModel.connectedPeers.filter { $0 != viewModel.meshService.myPeerID }.count
@@ -379,7 +367,7 @@ struct ContentView: View {
                                 .font(.system(size: 12, design: .monospaced))
                         }
                     }
-                    .foregroundColor(viewModel.isConnected ? textColor : Color.red)
+                    .foregroundColor(viewModel.isConnected ? themeManager.primaryTextColor : themeManager.errorColor)
                 }
                 .onTapGesture {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
@@ -387,11 +375,23 @@ struct ContentView: View {
                         sidebarDragOffset = 0
                     }
                 }
+                
+                // Dark/Light mode toggle
+                Button(action: {
+                    themeManager.toggleTheme()
+                }) {
+                    Image(systemName: themeManager.isDarkMode ? "moon.fill" : "sun.max.fill")
+                        .font(.system(size: 16))
+                        .foregroundColor(themeManager.isDarkMode ? themeManager.neonPurple : themeManager.neonYellow)
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.plain)
+                .padding(.leading, 8)
             }
         }
         .frame(height: 44) // Fixed height to prevent bouncing
         .padding(.horizontal, 12)
-        .background(backgroundColor.opacity(0.95))
+        .background(themeManager.backgroundColor.opacity(0.95))
     }
     
     private var messagesView: some View {
@@ -418,7 +418,7 @@ struct ContentView: View {
                             
                             if message.sender == "system" {
                                 // System messages
-                                Text(viewModel.formatMessageAsText(message, colorScheme: colorScheme))
+                                Text(viewModel.formatMessageAsText(message, colorScheme: themeManager.isDarkMode ? .dark : .light))
                                     .textSelection(.enabled)
                                     .fixedSize(horizontal: false, vertical: true)
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -427,7 +427,7 @@ struct ContentView: View {
                                 VStack(alignment: .leading, spacing: 8) {
                                     HStack(alignment: .top, spacing: 0) {
                                         // Single text view for natural wrapping
-                                        Text(viewModel.formatMessageAsText(message, colorScheme: colorScheme))
+                                        Text(viewModel.formatMessageAsText(message, colorScheme: themeManager.isDarkMode ? .dark : .light))
                                             .textSelection(.enabled)
                                             .fixedSize(horizontal: false, vertical: true)
                                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -435,7 +435,7 @@ struct ContentView: View {
                                         // Delivery status indicator for private messages
                                         if message.isPrivate && message.sender == viewModel.nickname,
                                            let status = message.deliveryStatus {
-                                            DeliveryStatusView(status: status, colorScheme: colorScheme)
+                                            DeliveryStatusView(status: status, colorScheme: themeManager.isDarkMode ? .dark : .light)
                                                 .padding(.leading, 4)
                                         }
                                     }
@@ -467,7 +467,7 @@ struct ContentView: View {
                 }
                 .padding(.vertical, 8)
             }
-            .background(backgroundColor)
+            .background(themeManager.backgroundColor)
             .onChange(of: viewModel.messages.count) { _ in
                 if viewModel.selectedPrivateChatPeer == nil && !viewModel.messages.isEmpty {
                     withAnimation {
@@ -523,7 +523,7 @@ struct ContentView: View {
                             HStack {
                                 Text("@\(suggestion)")
                                     .font(.system(size: 11, design: .monospaced))
-                                    .foregroundColor(textColor)
+                                    .foregroundColor(themeManager.primaryTextColor)
                                     .fontWeight(.medium)
                                 Spacer()
                             }
@@ -532,13 +532,13 @@ struct ContentView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                         }
                         .buttonStyle(.plain)
-                        .background(Color.gray.opacity(0.1))
+                        .background(themeManager.buttonBackgroundColor)
                     }
                 }
-                .background(backgroundColor)
+                .background(themeManager.backgroundColor)
                 .overlay(
                     RoundedRectangle(cornerRadius: 4)
-                        .stroke(secondaryTextColor.opacity(0.3), lineWidth: 1)
+                        .stroke(themeManager.dividerColor, lineWidth: 1)
                 )
                 .padding(.horizontal, 12)
             }
@@ -584,14 +584,14 @@ struct ContentView: View {
                                     // Show all aliases together
                                     Text(info.commands.joined(separator: ", "))
                                         .font(.system(size: 11, design: .monospaced))
-                                        .foregroundColor(textColor)
+                                        .foregroundColor(themeManager.primaryTextColor)
                                         .fontWeight(.medium)
                                     
                                     // Show syntax if any
                                     if let syntax = info.syntax {
                                         Text(syntax)
                                             .font(.system(size: 10, design: .monospaced))
-                                            .foregroundColor(secondaryTextColor.opacity(0.8))
+                                            .foregroundColor(themeManager.secondaryTextColor.opacity(0.8))
                                     }
                                     
                                     Spacer()
@@ -599,7 +599,7 @@ struct ContentView: View {
                                     // Show description
                                     Text(info.description)
                                         .font(.system(size: 10, design: .monospaced))
-                                        .foregroundColor(secondaryTextColor)
+                                        .foregroundColor(themeManager.secondaryTextColor)
                                 }
                                 .padding(.horizontal, 12)
                                 .padding(.vertical, 3)
@@ -610,10 +610,10 @@ struct ContentView: View {
                         }
                     }
                 }
-                .background(backgroundColor)
+                .background(themeManager.backgroundColor)
                 .overlay(
                     RoundedRectangle(cornerRadius: 4)
-                        .stroke(secondaryTextColor.opacity(0.3), lineWidth: 1)
+                        .stroke(themeManager.dividerColor, lineWidth: 1)
                 )
                 .padding(.horizontal, 12)
             }
@@ -622,21 +622,21 @@ struct ContentView: View {
             if viewModel.selectedPrivateChatPeer != nil {
                 Text("<@\(viewModel.nickname)> →")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(Color.orange)
+                    .foregroundColor(themeManager.privateMessageColor)
                     .lineLimit(1)
                     .fixedSize()
                     .padding(.leading, 12)
             } else if let currentChannel = viewModel.currentChannel, viewModel.passwordProtectedChannels.contains(currentChannel) {
                 Text("<@\(viewModel.nickname)> →")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(Color.orange)
+                    .foregroundColor(themeManager.privateMessageColor)
                     .lineLimit(1)
                     .fixedSize()
                     .padding(.leading, 12)
             } else {
                 Text("<@\(viewModel.nickname)>")
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(textColor)
+                    .foregroundColor(themeManager.primaryTextColor)
                     .lineLimit(1)
                     .fixedSize()
                     .padding(.leading, 12)
@@ -645,7 +645,7 @@ struct ContentView: View {
             TextField("", text: $messageText)
                 .textFieldStyle(.plain)
                 .font(.system(size: 14, design: .monospaced))
-                .foregroundColor(textColor)
+                .foregroundColor(themeManager.primaryTextColor)
                 .autocorrectionDisabled()
                 .focused($isTextFieldFocused)
                 .onChange(of: messageText) { newValue in
@@ -715,13 +715,13 @@ struct ContentView: View {
                     .foregroundColor(messageText.isEmpty ? Color.gray :
                                             (viewModel.selectedPrivateChatPeer != nil ||
                                              (viewModel.currentChannel != nil && viewModel.passwordProtectedChannels.contains(viewModel.currentChannel ?? "")))
-                                             ? Color.orange : textColor)
+                                             ? themeManager.privateMessageColor : themeManager.primaryTextColor)
             }
             .buttonStyle(.plain)
             .padding(.trailing, 12)
             }
             .padding(.vertical, 8)
-            .background(backgroundColor.opacity(0.95))
+            .background(themeManager.backgroundColor.opacity(0.95))
         }
         .onAppear {
             isTextFieldFocused = true
@@ -743,7 +743,7 @@ struct ContentView: View {
                     Text("CHANNELS")
                         .font(.system(size: 11, weight: .bold, design: .monospaced))
                 }
-                .foregroundColor(secondaryTextColor)
+                .foregroundColor(themeManager.secondaryTextColor)
                 .padding(.horizontal, 12)
                 
                 ForEach(Array(viewModel.joinedChannels).sorted(), id: \.self) { channel in
@@ -774,12 +774,12 @@ struct ContentView: View {
                 if viewModel.passwordProtectedChannels.contains(channel) {
                     Image(systemName: "lock.fill")
                         .font(.system(size: 10))
-                        .foregroundColor(secondaryTextColor)
+                        .foregroundColor(themeManager.secondaryTextColor)
                 }
                 
                 Text(channel)
                     .font(.system(size: 14, design: .monospaced))
-                    .foregroundColor(viewModel.currentChannel == channel ? Color.blue : textColor)
+                    .foregroundColor(viewModel.currentChannel == channel ? themeManager.channelColor : themeManager.primaryTextColor)
                 
                 Spacer()
                 
@@ -787,10 +787,10 @@ struct ContentView: View {
                 if let unreadCount = viewModel.unreadChannelMessages[channel], unreadCount > 0 {
                     Text("\(unreadCount)")
                         .font(.system(size: 10, weight: .bold, design: .monospaced))
-                        .foregroundColor(backgroundColor)
+                        .foregroundColor(themeManager.backgroundColor)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
-                        .background(Color.orange)
+                        .background(themeManager.privateMessageColor)
                         .clipShape(Capsule())
                 }
                 
@@ -803,7 +803,7 @@ struct ContentView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, 12)
         .padding(.vertical, 4)
-        .background(viewModel.currentChannel == channel ? backgroundColor.opacity(0.5) : Color.clear)
+        .background(viewModel.currentChannel == channel ? themeManager.secondaryBackgroundColor : Color.clear)
     }
     
     @ViewBuilder
@@ -825,13 +825,13 @@ struct ContentView: View {
                         Image(systemName: viewModel.passwordProtectedChannels.contains(channel) ? "lock.fill" : "lock")
                             .font(.system(size: 10))
                     }
-                    .foregroundColor(viewModel.passwordProtectedChannels.contains(channel) ? backgroundColor : secondaryTextColor)
+                    .foregroundColor(viewModel.passwordProtectedChannels.contains(channel) ? themeManager.backgroundColor : themeManager.secondaryTextColor)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 2)
-                    .background(viewModel.passwordProtectedChannels.contains(channel) ? Color.orange : Color.clear)
+                    .background(viewModel.passwordProtectedChannels.contains(channel) ? themeManager.privateMessageColor : Color.clear)
                     .overlay(
                         RoundedRectangle(cornerRadius: 4)
-                            .stroke(viewModel.passwordProtectedChannels.contains(channel) ? Color.orange : secondaryTextColor.opacity(0.5), lineWidth: 1)
+                            .stroke(viewModel.passwordProtectedChannels.contains(channel) ? themeManager.privateMessageColor : themeManager.dividerColor, lineWidth: 1)
                     )
                 }
                 .buttonStyle(.plain)
@@ -843,12 +843,12 @@ struct ContentView: View {
             }) {
                 Text("leave channel")
                     .font(.system(size: 10, design: .monospaced))
-                    .foregroundColor(secondaryTextColor)
+                    .foregroundColor(themeManager.secondaryTextColor)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 2)
                     .overlay(
                         RoundedRectangle(cornerRadius: 4)
-                            .stroke(secondaryTextColor.opacity(0.5), lineWidth: 1)
+                            .stroke(themeManager.dividerColor, lineWidth: 1)
                     )
             }
             .buttonStyle(.plain)
@@ -875,12 +875,12 @@ struct ContentView: View {
                 HStack {
                     Text("YOUR NETWORK")
                         .font(.system(size: 16, weight: .bold, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundColor(themeManager.primaryTextColor)
                     Spacer()
                 }
                 .frame(height: 44) // Match header height
                 .padding(.horizontal, 12)
-                .background(backgroundColor.opacity(0.95))
+                .background(themeManager.backgroundColor.opacity(0.95))
                 
                 Divider()
             
@@ -901,7 +901,7 @@ struct ContentView: View {
                         if let currentChannel = viewModel.currentChannel {
                             Text("IN \(currentChannel.uppercased())")
                                 .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                                .foregroundColor(secondaryTextColor)
+                                .foregroundColor(themeManager.secondaryTextColor)
                                 .padding(.horizontal, 12)
                         } else if !viewModel.connectedPeers.isEmpty {
                             HStack(spacing: 4) {
@@ -910,21 +910,21 @@ struct ContentView: View {
                                 Text("PEOPLE")
                                     .font(.system(size: 11, weight: .bold, design: .monospaced))
                             }
-                            .foregroundColor(secondaryTextColor)
+                            .foregroundColor(themeManager.secondaryTextColor)
                             .padding(.horizontal, 12)
                         }
                         
                         if viewModel.connectedPeers.isEmpty {
                             Text("No one connected")
                                 .font(.system(size: 14, design: .monospaced))
-                                .foregroundColor(secondaryTextColor)
+                                .foregroundColor(themeManager.secondaryTextColor)
                                 .padding(.horizontal)
                         } else if let currentChannel = viewModel.currentChannel,
                                   let channelMemberIDs = viewModel.channelMembers[currentChannel],
                                   channelMemberIDs.isEmpty {
                             Text("No one in this channel yet")
                                 .font(.system(size: 14, design: .monospaced))
-                                .foregroundColor(secondaryTextColor)
+                                .foregroundColor(themeManager.secondaryTextColor)
                                 .padding(.horizontal)
                         } else {
                             let peerNicknames = viewModel.meshService.getPeerNicknames()
@@ -977,14 +977,14 @@ struct ContentView: View {
                                 if isMe {
                                     Image(systemName: "person.fill")
                                         .font(.system(size: 10))
-                                        .foregroundColor(textColor)
+                                        .foregroundColor(themeManager.primaryTextColor)
                                 } else if viewModel.unreadPrivateMessages.contains(peerID) {
                                     Image(systemName: "envelope.fill")
                                         .font(.system(size: 12))
-                                        .foregroundColor(Color.orange)
+                                        .foregroundColor(themeManager.privateMessageColor)
                                 } else {
                                     Circle()
-                                        .fill(viewModel.getRSSIColor(rssi: rssi, colorScheme: colorScheme))
+                                        .fill(viewModel.getRSSIColor(rssi: rssi, colorScheme: themeManager.isDarkMode ? .dark : .light))
                                         .frame(width: 8, height: 8)
                                 }
                                 
@@ -995,7 +995,7 @@ struct ContentView: View {
                                     }) {
                                         Image(systemName: isFavorite ? "star.fill" : "star")
                                             .font(.system(size: 12))
-                                            .foregroundColor(isFavorite ? Color.yellow : secondaryTextColor)
+                                            .foregroundColor(isFavorite ? themeManager.favoriteColor : themeManager.secondaryTextColor)
                                     }
                                     .buttonStyle(.plain)
                                 }
@@ -1005,7 +1005,7 @@ struct ContentView: View {
                                     HStack {
                                         Text(displayName + " (you)")
                                             .font(.system(size: 14, design: .monospaced))
-                                            .foregroundColor(textColor)
+                                            .foregroundColor(themeManager.primaryTextColor)
                                         
                                         Spacer()
                                     }
@@ -1022,7 +1022,7 @@ struct ContentView: View {
                                         HStack {
                                             Text(displayName)
                                                 .font(.system(size: 14, design: .monospaced))
-                                                .foregroundColor(peerNicknames[peerID] != nil ? textColor : secondaryTextColor)
+                                                .foregroundColor(peerNicknames[peerID] != nil ? themeManager.primaryTextColor : themeManager.secondaryTextColor)
                                             
                                             Spacer()
                                         }
@@ -1042,7 +1042,7 @@ struct ContentView: View {
             
             Spacer()
         }
-        .background(backgroundColor)
+        .background(themeManager.backgroundColor)
         }
     }
 }
@@ -1089,7 +1089,7 @@ struct MessageContentView: View {
             } else if segment.type == "mention" {
                 result = result + Text(segment.text)
                     .font(.system(size: 14, weight: .semibold, design: .monospaced))
-                    .foregroundColor(Color.orange)
+                    .foregroundColor(Color.orange) // Note: This view is not used, keeping hardcoded color
             } else {
                 result = result + Text(segment.text)
                     .font(.system(size: 14, design: .monospaced))
@@ -1159,26 +1159,19 @@ struct MessageContentView: View {
 struct DeliveryStatusView: View {
     let status: DeliveryStatus
     let colorScheme: ColorScheme
-    
-    private var textColor: Color {
-        colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0)
-    }
-    
-    private var secondaryTextColor: Color {
-        colorScheme == .dark ? Color.green.opacity(0.8) : Color(red: 0, green: 0.5, blue: 0).opacity(0.8)
-    }
+    @EnvironmentObject var themeManager: ThemeManager
     
     var body: some View {
         switch status {
         case .sending:
             Image(systemName: "circle")
                 .font(.system(size: 10))
-                .foregroundColor(secondaryTextColor.opacity(0.6))
+                .foregroundColor(themeManager.secondaryTextColor.opacity(0.6))
             
         case .sent:
             Image(systemName: "checkmark")
                 .font(.system(size: 10))
-                .foregroundColor(secondaryTextColor.opacity(0.6))
+                .foregroundColor(themeManager.secondaryTextColor.opacity(0.6))
             
         case .delivered(let nickname, _):
             HStack(spacing: -2) {
@@ -1187,7 +1180,7 @@ struct DeliveryStatusView: View {
                 Image(systemName: "checkmark")
                     .font(.system(size: 10))
             }
-            .foregroundColor(textColor.opacity(0.8))
+            .foregroundColor(themeManager.primaryTextColor.opacity(0.8))
             .help("Delivered to \(nickname)")
             
         case .read(let nickname, _):
@@ -1213,7 +1206,7 @@ struct DeliveryStatusView: View {
                 Text("\(reached)/\(total)")
                     .font(.system(size: 10, design: .monospaced))
             }
-            .foregroundColor(secondaryTextColor.opacity(0.6))
+            .foregroundColor(themeManager.secondaryTextColor.opacity(0.6))
             .help("Delivered to \(reached) of \(total) members")
         }
     }

--- a/bitchat/Views/LinkPreviewView.swift
+++ b/bitchat/Views/LinkPreviewView.swift
@@ -14,19 +14,11 @@ import LinkPresentation
 struct LinkPreviewView: View {
     let url: URL
     let title: String?
-    @Environment(\.colorScheme) var colorScheme
+    @EnvironmentObject var themeManager: ThemeManager
     @State private var metadata: LPLinkMetadata?
     
-    private var textColor: Color {
-        colorScheme == .dark ? Color.green : Color(red: 0, green: 0.5, blue: 0)
-    }
-    
-    private var backgroundColor: Color {
-        colorScheme == .dark ? Color.black : Color.white
-    }
-    
     private var borderColor: Color {
-        textColor.opacity(0.3)
+        themeManager.dividerColor
     }
     
     var body: some View {
@@ -87,14 +79,14 @@ struct LinkPreviewView: View {
                     // Title
                     Text(metadata?.title ?? title ?? url.host ?? "Link")
                         .font(.system(size: 14, weight: .semibold, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundColor(themeManager.primaryTextColor)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                     
                     // Host
                     Text(url.host ?? url.absoluteString)
                         .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(textColor.opacity(0.6))
+                        .foregroundColor(themeManager.secondaryTextColor)
                         .lineLimit(1)
                 }
                 
@@ -104,7 +96,7 @@ struct LinkPreviewView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(colorScheme == .dark ? Color.gray.opacity(0.15) : Color.gray.opacity(0.08))
+                    .fill(themeManager.secondaryBackgroundColor)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 10)
@@ -133,14 +125,14 @@ struct LinkPreviewView: View {
                     // Title
                     Text(title ?? url.host ?? "Link")
                         .font(.system(size: 14, weight: .semibold, design: .monospaced))
-                        .foregroundColor(textColor)
+                        .foregroundColor(themeManager.primaryTextColor)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                     
                     // URL
                     Text(url.absoluteString)
                         .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(Color.blue)
+                        .foregroundColor(themeManager.linkColor)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
@@ -150,13 +142,13 @@ struct LinkPreviewView: View {
                 // Arrow indicator
                 Image(systemName: "chevron.right")
                     .font(.system(size: 14))
-                    .foregroundColor(textColor.opacity(0.5))
+                    .foregroundColor(themeManager.secondaryTextColor)
             }
             .padding(12)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(colorScheme == .dark ? Color.gray.opacity(0.15) : Color.gray.opacity(0.08))
+                    .fill(themeManager.secondaryBackgroundColor)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 10)


### PR DESCRIPTION
- Created ThemeManager service for centralized theme management
- Added dark/light mode toggle button in top-right corner
- Updated all views to support dynamic theming
- Theme preference persists across app launches
- Dark background (#1E1E1E) for comfortable viewing
- Neon accent colors: green, blue, purple, pink, yellow, orange