### PR TITLE
Fix: Prevent potential buffer overflow in CompressionUtil.swift

### DIFF
--- a/bitchat/Utils/CompressionUtil.swift
+++ b/bitchat/Utils/CompressionUtil.swift
@@ -18,7 +18,8 @@ struct CompressionUtil {
         // Skip compression for small data
         guard data.count >= compressionThreshold else { return nil }
         
-        let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: data.count)
+        let maxCompressedSize = data.count + (data.count / 255) + 16
+        let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: maxCompressedSize)
         defer { destinationBuffer.deallocate() }
         
         let compressedSize = data.withUnsafeBytes { sourceBuffer in


### PR DESCRIPTION
This PR addresses a potential buffer overflow vulnerability in the compress function within CompressionUtil.swift. The original implementation allocated the destination buffer for compressed data with the size of the uncompressed data. In certain edge cases, compressed data can be larger than the original, leading to a buffer overflow. This fix allocates a larger, safer buffer for the compressed data using a common LZ4 worst-case heuristic (source_size + source_size / 255 + 16). This ensures that the buffer is always sufficiently large to prevent overflows, improving the stability and security of the compression utility.