### PR TITLE
Notification tap fails to open the private chat.

### DIFF
--- a/bitchat/BitchatApp.swift
+++ b/bitchat/BitchatApp.swift
@@ -145,7 +145,7 @@ class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
         if identifier.hasPrefix("private-") {
             // Extract sender from notification title
             let title = response.notification.request.content.title
-            if let senderName = title.replacingOccurrences(of: "Private message from ", with: "").nilIfEmpty {
+            if let senderName = title.replacingOccurrences(of: "🔒 private message from ", with: "").nilIfEmpty {
                 // Find peer ID and open chat
                 if let peerID = chatViewModel?.getPeerIDForNickname(senderName) {
                     DispatchQueue.main.async {


### PR DESCRIPTION
### Steps to Reproduce

1. X sends a private message to Y.
2. Y taps the notification.
3. The app resumes to the last open screen instead of opening the private chat with X.

### Fix

- Correct the notification title prefix.