### PR TITLE
fix(ChatViewModel): add deinit cleanup for NotificationCenter observers and timers

### DIFF
--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -1702,6 +1702,13 @@ class ChatViewModel: ObservableObject {
         
         return result
     }
+    
+    // Clean up observers, timers, and subscriptions to prevent memory leaks and callbacks
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        nicknameSaveTimer?.invalidate()
+        deliveryTrackerCancellable?.cancel()
+    }
 }
 
 extension ChatViewModel: BitchatDelegate {


### PR DESCRIPTION
**fix(ChatViewModel): add deinit cleanup for NotificationCenter observers and timers**

---

### Summary

Added a `deinit` method to `ChatViewModel` to clean up NotificationCenter observers, timers, and Combine subscriptions when the view model is deallocated. Without this, resources would persist beyond the lifecycle of the instance, leading to memory leaks and unpredictable behavior.

---

### Problem

`ChatViewModel` registers for system notifications during initialization using:

```swift
NotificationCenter.default.addObserver(self, selector: ..., name: ..., object: nil)
```

It also creates:
- A debounce timer (`nicknameSaveTimer`) in the `nickname` setter
- A Combine subscription (`deliveryTrackerCancellable`) to track delivery status

Previously, there was **no `deinit` method**, so none of these were cleaned up when the object was released. This could lead to:

- Retained memory (due to observers)
- Dangling callbacks on deallocated instances
- Flaky behavior during testing or navigation

---

### Fix

Added a `deinit` method to the class (within the primary `ChatViewModel` declaration):

```swift
deinit {
    NotificationCenter.default.removeObserver(self)
    nicknameSaveTimer?.invalidate()
    deliveryTrackerCancellable?.cancel()
}
```

This ensures proper cleanup when the view model is deallocated.

---

### Benefits

- **Prevents memory leaks**: by removing retained observers
- **Improves test reliability**: by preventing callbacks on dead objects
- **Brings lifecycle hygiene**: in line with best practices used across the codebase